### PR TITLE
navajo: Brings `envelope::sync::Envelope` in line with `Envelope`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.4] 2023-04-25
+- navajo: `envelope::sync::Envelope` associated error types no longer require `Error`, bringing it inline with `envelope::Envelope`
+
 ## [0.0.3] 2023-04-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "navajo"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "aead",
  "aes",
@@ -1698,14 +1698,14 @@ version = "0.0.0"
 
 [[package]]
 name = "navajo-cli"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
  "clap",
  "hex",
  "navajo",
- "navajo-gcp 0.0.2",
+ "navajo-gcp",
  "serde",
  "serde_json",
  "shellexpand",
@@ -1715,29 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "navajo-gcp"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8563347d9f367738b8862a644f693f7b713a5dbcc4a683a4e6a9452ba059a3"
-dependencies = [
- "async-trait",
- "base64 0.21.0",
- "crc32c",
- "gcloud-sdk",
- "inherent",
- "kms-aead",
- "navajo",
- "once_cell",
- "prost",
- "prost-types",
- "secret-vault-value",
- "tokio",
- "tonic",
- "url",
-]
-
-[[package]]
-name = "navajo-gcp"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "async-trait",
  "base64 0.21.0",

--- a/navajo-cli/Cargo.toml
+++ b/navajo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "navajo-cli"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Chance Dinkins"]
@@ -10,14 +10,14 @@ description = "Navajo CLI"
 name = "navajo"
 
 [dependencies]
-navajo = { version = "0.0.3", features = [
+navajo = { version = "0.0.4", features = [
 	"std",
 	"blake3",
 	"sha3",
 	"cmac",
 	"aes",
 ] }
-navajo-gcp = { version = "0.0.2" }
+navajo-gcp = { version = "0.0.4" }
 
 strum = { version = "0.24", features = ["derive", "strum_macros"] }
 clap = { version = "4.2", features = ["derive", "wrap_help", "env"] }

--- a/navajo-gcp/Cargo.toml
+++ b/navajo-gcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "navajo-gcp"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Chance Dinkins"]
@@ -8,7 +8,7 @@ description = "Navajo GCP KMS integration"
 
 [dependencies]
 kms-aead = { version = "0.15", features = ["gcp-kms-encryption"] }
-navajo = "0.0.3"
+navajo = "0.0.4"
 tokio = { version = "1.26", features = ["full"] }
 secret-vault-value = { version = "0.3" }
 async-trait = "0.1"

--- a/navajo/Cargo.toml
+++ b/navajo/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "navajo"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Chance Dinkins"]

--- a/navajo/src/envelope.rs
+++ b/navajo/src/envelope.rs
@@ -35,8 +35,8 @@ pub mod sync {
     use alloc::vec::Vec;
 
     pub trait Envelope {
-        type EncryptError: super::Error + Send + Sync;
-        type DecryptError: super::Error + Send + Sync;
+        type EncryptError: core::fmt::Display + core::fmt::Debug + Send + Sync;
+        type DecryptError: core::fmt::Display + core::fmt::Debug + Send + Sync;
 
         fn encrypt_dek<A, P>(
             &self,


### PR DESCRIPTION
currently, the async `Envelope trait's associated error types are:
```rust
pub trait Envelope {
    type EncryptError: core::fmt::Display + core::fmt::Debug + Send + Sync;
    type DecryptError: core::fmt::Display + core::fmt::Debug + Send + Sync;
    // ...
}
```
while the sync version is:
```rust
pub trait Envelope {
    type EncryptError: super::Error + Send + Sync;
    type DecryptError: super::Error + Send + Sync;
    // ...
}
```

This brnigs both in line by replacing `super::Error` with `Display + Debug`